### PR TITLE
A couple of Python 3 fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def log(what):
         if cli.frida_script is not None and cli.frida_script.exports.ivp(what):
             c = 'red highlight'
         print('-> %s (%s)' % (Color.colorify(hex((what + (1 << 32)) % (1 << 32)), c), Color.colorify(str(what), 'bold')))
-    elif t is unicode:
+    elif t is six.text_type:
         print('-> %s' % what.encode('ascii', 'ignore'))
     else:
         pprint(what)
@@ -1343,7 +1343,7 @@ class FridaCli(object):
         atexit.register(readline.write_history_file, hist)
 
         while True:
-            inp = raw_input('')
+            inp = six.moves.input().strip()
             if len(inp) > 0:
                 self.cmd_manager.handle_command(inp)
 


### PR DESCRIPTION
flake8 testing of https://github.com/iGio90/frick on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./main.py:69:15: F821 undefined name 'unicode'
    elif t is unicode:
              ^

./main.py:1346:19: F821 undefined name 'raw_input'
            inp = raw_input('')
                  ^

2     F821 undefined name 'unicode'
2
```